### PR TITLE
Import PK from the public env

### DIFF
--- a/docs/spa/quickstart.md
+++ b/docs/spa/quickstart.md
@@ -31,7 +31,7 @@ All Clerk runes and components must be children of the `<ClerkProvider>` compone
 <script lang="ts">
 	import type { Snippet } from 'svelte';
 	import { ClerkProvider } from 'svelte-clerk/client';
-	import { PUBLIC_CLERK_PUBLISHABLE_KEY } from '$env/static/private';
+	import { PUBLIC_CLERK_PUBLISHABLE_KEY } from '$env/static/public';
 
 	const { children }: { children: Snippet } = $props();
 </script>


### PR DESCRIPTION
Public env vars need to be imported via `$env/static/public` instead of `$env/static/private`.

